### PR TITLE
docs: update for v0.7.7

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -75,6 +75,7 @@
               "sandboxes/quickstart",
               "sandboxes/ephemeral",
               "sandboxes/persistent",
+              "sandboxes/egress",
               "sandboxes/templates",
               "sandboxes/warm-pool",
               "sandboxes/api-reference"

--- a/sandbox.mdx
+++ b/sandbox.mdx
@@ -8,7 +8,7 @@ icon: "box"
 Sandboxes are currently in **beta**. Do not run production workloads on sandboxes — data loss may occur during this phase.
 </Warning>
 
-Sandboxes are lightweight, isolated virtual machines built on [Firecracker](https://firecracker-microvm.github.io/) that spin up in milliseconds. Each sandbox runs a full Linux environment from a pre-built template, with SSH access, filesystem operations, and command execution via API.
+Sandboxes are lightweight, isolated virtual machines built on [Firecracker](https://firecracker-microvm.github.io/) that spin up in milliseconds. Each sandbox runs a full Linux environment from a pre-built template, with filesystem operations and command execution via API.
 
 ## Key concepts
 
@@ -43,7 +43,7 @@ Every sandbox is a Firecracker microVM running on a Linux host with KVM support:
 
 1. **Create** — A sandbox is created from a template. If a warm pool VM is available, it's claimed instantly. Otherwise, a new VM cold-boots (~2-3 seconds).
 
-2. **Run** — The sandbox is a fully functional Linux VM with SSH access. Execute commands, upload/download files, and interact via the REST API or CLI.
+2. **Run** — The sandbox is a fully functional Linux VM. Execute commands, upload/download files, and interact via the REST API or CLI.
 
 3. **Suspend** (persistent only) — After the idle timeout expires, the VM's full memory and CPU state are snapshotted to disk. The Firecracker process is killed, freeing all host resources.
 

--- a/sandboxes/api-reference.mdx
+++ b/sandboxes/api-reference.mdx
@@ -75,9 +75,7 @@ curl -X POST http://localhost:8080/v1/sandboxes \
   "timeout_seconds": 600,
   "expires_at": "2026-04-05T15:10:00Z",
   "egress": {
-    "mode": "deny_all",
-    "allow_cidrs": ["1.1.1.1/32"],
-    "allow_ports": [443]
+    "mode": "allow_all"
   },
   "created_at": "2026-04-05T15:00:00Z",
   "updated_at": "2026-04-05T15:00:00Z"

--- a/sandboxes/api-reference.mdx
+++ b/sandboxes/api-reference.mdx
@@ -36,6 +36,15 @@ All sandbox endpoints are under `/v1/sandboxes`. Requests require authentication
   Arbitrary metadata as key-value pairs.
 </ParamField>
 
+<ParamField body="egress" type="object">
+  Outbound firewall policy. If omitted, the template's default egress policy is used (which itself defaults to `allow_all`). See [Egress controls](/sandboxes/egress).
+
+  - `mode` (string, required) — `allow_all` or `deny_all`
+  - `allow_cidrs` (string[]) — CIDRs to allow when mode is `deny_all`
+  - `deny_cidrs` (string[]) — CIDRs to explicitly block (evaluated before allows)
+  - `allow_ports` (integer[]) — Restrict `allow_cidrs` to these destination TCP ports
+</ParamField>
+
 ```bash
 POST /v1/sandboxes
 ```
@@ -65,6 +74,11 @@ curl -X POST http://localhost:8080/v1/sandboxes \
   "env": {"API_KEY": "sk-..."},
   "timeout_seconds": 600,
   "expires_at": "2026-04-05T15:10:00Z",
+  "egress": {
+    "mode": "deny_all",
+    "allow_cidrs": ["1.1.1.1/32"],
+    "allow_ports": [443]
+  },
   "created_at": "2026-04-05T15:00:00Z",
   "updated_at": "2026-04-05T15:00:00Z"
 }
@@ -75,7 +89,7 @@ curl -X POST http://localhost:8080/v1/sandboxes \
 | Status | Condition |
 |--------|-----------|
 | `201` | Sandbox created |
-| `400` | Invalid mode, size, or timeout |
+| `400` | Invalid mode, size, timeout, or egress policy |
 | `404` | Template not found |
 
 ---
@@ -287,7 +301,6 @@ curl -X POST http://localhost:8080/v1/sandboxes/sbx_abc123/execute \
 | `200` | Command completed (check `exit_code` for success/failure) |
 | `400` | Missing command or invalid timeout |
 | `409` | Sandbox not running |
-| `503` | SSH key not configured on server |
 
 ---
 

--- a/sandboxes/egress.mdx
+++ b/sandboxes/egress.mdx
@@ -1,0 +1,158 @@
+---
+title: "Egress controls"
+description: "Restrict outbound network access from sandbox VMs"
+icon: "shield-halved"
+---
+
+By default, sandbox VMs have unrestricted outbound access to the internet. Egress controls let you restrict that access at the iptables level — per sandbox or as a default for all sandboxes created from a given template.
+
+## Modes
+
+| Mode | Behavior |
+|------|----------|
+| `allow_all` | All outbound traffic is permitted (default) |
+| `deny_all` | All outbound traffic is dropped unless explicitly allowed via `allow_cidrs` |
+
+The metadata service at `169.254.169.254` is always reachable regardless of the policy. The in-VM agent daemon uses it to fetch its auth token at boot.
+
+## Policy fields
+
+<ParamField body="mode" type="string" required>
+  `allow_all` or `deny_all`.
+</ParamField>
+
+<ParamField body="allow_cidrs" type="string[]">
+  CIDRs to allow outbound traffic to. Only evaluated when `mode` is `deny_all`. Example: `["1.1.1.1/32", "8.8.8.8/32"]`.
+</ParamField>
+
+<ParamField body="deny_cidrs" type="string[]">
+  CIDRs to explicitly deny. Evaluated before `allow_cidrs`, so use this to carve out subnets from a broad allow rule. Example: `["10.0.0.0/8"]`.
+</ParamField>
+
+<ParamField body="allow_ports" type="integer[]">
+  Restrict `allow_cidrs` rules to these destination TCP ports. If omitted, the allowed CIDRs are reachable on any port. Requires `allow_cidrs` to be set. Example: `[443, 8080]`.
+</ParamField>
+
+## Validation
+
+The API validates egress policies on create and returns `400` for:
+
+- Unknown mode (must be `allow_all` or `deny_all`)
+- `allow_all` combined with `allow_cidrs`, `deny_cidrs`, or `allow_ports`
+- `allow_ports` set without `allow_cidrs`
+- `deny_cidrs` containing the metadata service range (`169.254.0.0/16`)
+- Malformed CIDR notation
+- Port numbers outside 1–65535
+
+## Per-sandbox egress
+
+Pass an `egress` object when creating a sandbox to override the template default.
+
+<Tabs>
+  <Tab title="CLI">
+    ```bash
+    # Block all outbound except HTTPS to Cloudflare DNS
+    zwrm sandbox create --template python \
+      --egress-mode deny_all \
+      --egress-allow-cidr 1.1.1.1/32 \
+      --egress-allow-cidr 1.0.0.1/32 \
+      --egress-allow-port 443
+
+    # Deny a specific subnet, allow everything else
+    zwrm sandbox create --template python \
+      --egress-mode allow_all \
+      --egress-deny-cidr 10.0.0.0/8
+    ```
+
+    Flags (available on `sandbox create` and `sandbox run`):
+
+    | Flag | Description |
+    |------|-------------|
+    | `--egress-mode` | `allow_all` or `deny_all`. When omitted and other egress flags are set, defaults to `deny_all`. |
+    | `--egress-allow-cidr` | Allow outbound to this CIDR (repeatable). Implies `deny_all`. |
+    | `--egress-deny-cidr` | Deny outbound to this CIDR (repeatable). |
+    | `--egress-allow-port` | Restrict `allow_cidrs` to this TCP port (repeatable). |
+  </Tab>
+  <Tab title="API">
+    ```bash
+    curl -X POST http://localhost:8080/v1/sandboxes \
+      -H "Content-Type: application/json" \
+      -d '{
+        "template": "python",
+        "mode": "ephemeral",
+        "timeout": "10m",
+        "egress": {
+          "mode": "deny_all",
+          "allow_cidrs": ["1.1.1.1/32", "1.0.0.1/32"],
+          "allow_ports": [443]
+        }
+      }'
+    ```
+
+    The resolved policy is echoed back in the sandbox response:
+
+    ```json
+    {
+      "id": "sbx_abc123",
+      "status": "running",
+      "egress": {
+        "mode": "deny_all",
+        "allow_cidrs": ["1.1.1.1/32", "1.0.0.1/32"],
+        "allow_ports": [443]
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## Template-level egress defaults
+
+Set a default egress policy on a template so every sandbox created from it inherits the same restrictions.
+
+<Tabs>
+  <Tab title="CLI">
+    ```bash
+    zwrm templates create secure-python \
+      --dockerfile ./Dockerfile \
+      --egress-mode deny_all \
+      --egress-allow-cidr 0.0.0.0/0 \
+      --egress-deny-cidr 10.0.0.0/8 \
+      --egress-deny-cidr 172.16.0.0/12 \
+      --egress-deny-cidr 192.168.0.0/16
+    ```
+
+    This template allows all external internet traffic but blocks RFC 1918 private address space.
+  </Tab>
+  <Tab title="API">
+    ```bash
+    curl -X POST http://localhost:8080/v1/templates \
+      -H "Content-Type: application/json" \
+      -d '{
+        "name": "secure-python",
+        "dockerfile": "FROM python:3.12-slim",
+        "egress": {
+          "mode": "deny_all",
+          "allow_cidrs": ["0.0.0.0/0"],
+          "deny_cidrs": ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
+        }
+      }'
+    ```
+  </Tab>
+</Tabs>
+
+When creating a sandbox, you can override the template's default by passing a different `egress` object. Passing no `egress` field inherits the template default.
+
+<Info>
+Rebuilding a template (`zwrm templates rebuild`) does not change the stored egress policy. The policy is attached to the template record, not the image.
+</Info>
+
+## How it works
+
+Egress rules are implemented as iptables rules in the `ZWRM` chain on the host. When a sandbox is created with a `deny_all` policy, the manager installs:
+
+1. **Allow rules** — one `ACCEPT` per `allow_cidrs` entry (optionally port-scoped), inserted near the top of the chain
+2. **Deny rule** — a final `DROP` for all traffic from the sandbox IP, appended at the bottom
+
+The metadata service (`169.254.169.254/32`) always has an unconditional `ACCEPT` that sits above per-sandbox rules.
+
+Rules are cleaned up automatically when the sandbox is destroyed or suspended.

--- a/sandboxes/egress.mdx
+++ b/sandboxes/egress.mdx
@@ -58,9 +58,10 @@ Pass an `egress` object when creating a sandbox to override the template default
       --egress-allow-cidr 1.0.0.1/32 \
       --egress-allow-port 443
 
-    # Deny a specific subnet, allow everything else
+    # Allow all external traffic but deny a specific subnet
     zwrm sandbox create --template python \
-      --egress-mode allow_all \
+      --egress-mode deny_all \
+      --egress-allow-cidr 0.0.0.0/0 \
       --egress-deny-cidr 10.0.0.0/8
     ```
 
@@ -71,7 +72,7 @@ Pass an `egress` object when creating a sandbox to override the template default
     | `--egress-mode` | `allow_all` or `deny_all`. When omitted and other egress flags are set, defaults to `deny_all`. |
     | `--egress-allow-cidr` | Allow outbound to this CIDR (repeatable). Implies `deny_all`. |
     | `--egress-deny-cidr` | Deny outbound to this CIDR (repeatable). |
-    | `--egress-allow-port` | Restrict `allow_cidrs` to this TCP port (repeatable). |
+    | `--egress-allow-port` | Restrict `--egress-allow-cidr` to this TCP port (repeatable). |
   </Tab>
   <Tab title="API">
     ```bash

--- a/sandboxes/ephemeral.mdx
+++ b/sandboxes/ephemeral.mdx
@@ -28,6 +28,10 @@ A background reaper loop runs every 10 seconds and destroys any ephemeral sandbo
     - `--timeout` — Duration until auto-destroy (default: `5m`, max: `24h`)
     - `--size` — VM preset (default: `shared-cpu-1x`)
     - `--env KEY=VALUE` — Environment variables (repeatable)
+    - `--egress-mode` — Outbound firewall mode: `allow_all` or `deny_all`
+    - `--egress-allow-cidr CIDR` — Allow outbound to this CIDR (repeatable; implies `deny_all`)
+    - `--egress-deny-cidr CIDR` — Explicitly deny outbound to this CIDR (repeatable)
+    - `--egress-allow-port PORT` — Restrict allowed CIDRs to this TCP port (repeatable)
   </Tab>
   <Tab title="API">
     ```bash
@@ -71,7 +75,7 @@ The maximum timeout is 24 hours (`86400s`). Keepalive requests exceeding this ar
 
 ## Executing commands
 
-Run a command inside the sandbox. The command executes via SSH and returns stdout, stderr, exit code, and duration.
+Run a command inside the sandbox. The command executes inside the VM via the in-VM agent daemon and returns stdout, stderr, exit code, and duration.
 
 <Tabs>
   <Tab title="CLI">

--- a/sandboxes/persistent.mdx
+++ b/sandboxes/persistent.mdx
@@ -28,6 +28,10 @@ Persistent sandboxes are long-lived environments designed for development worklo
     - `--idle-timeout` — Duration of inactivity before auto-suspend (default: `10m`)
     - `--size` — VM preset (default: `shared-cpu-1x`)
     - `--env KEY=VALUE` — Environment variables (repeatable)
+    - `--egress-mode` — Outbound firewall mode: `allow_all` or `deny_all`
+    - `--egress-allow-cidr CIDR` — Allow outbound to this CIDR (repeatable; implies `deny_all`)
+    - `--egress-deny-cidr CIDR` — Explicitly deny outbound to this CIDR (repeatable)
+    - `--egress-allow-port PORT` — Restrict allowed CIDRs to this TCP port (repeatable)
   </Tab>
   <Tab title="API">
     ```bash

--- a/sandboxes/quickstart.mdx
+++ b/sandboxes/quickstart.mdx
@@ -40,7 +40,7 @@ zwrm sandbox exec sbx_abc123 -- python3 -c "print('Hello from ZWRM!')"
 Hello from ZWRM!
 ```
 
-Commands run via SSH inside the VM. You can set a custom timeout and working directory:
+Commands run inside the VM via the in-VM agent daemon. You can set a custom timeout and working directory:
 
 ```bash
 zwrm sandbox exec sbx_abc123 --timeout 60s --workdir /home/user -- bash -c "ls -la"

--- a/sandboxes/templates.mdx
+++ b/sandboxes/templates.mdx
@@ -61,6 +61,20 @@ Custom templates are built from a Dockerfile. The Dockerfile defines the complet
     ```bash
     zwrm templates list
     ```
+
+    To set a default egress policy for all sandboxes created from this template:
+    ```bash
+    zwrm templates create my-ml --dockerfile ./Dockerfile \
+      --egress-mode deny_all \
+      --egress-allow-cidr 0.0.0.0/0 \
+      --egress-deny-cidr 10.0.0.0/8
+    ```
+
+    Egress flags:
+    - `--egress-mode` — `allow_all` or `deny_all` default for sandboxes from this template
+    - `--egress-allow-cidr CIDR` — Default allowed outbound CIDR (repeatable; implies `deny_all`)
+    - `--egress-deny-cidr CIDR` — Default denied outbound CIDR (repeatable)
+    - `--egress-allow-port PORT` — Default TCP port restriction for `allow_cidrs` (repeatable)
   </Tab>
   <Tab title="API">
     ```bash
@@ -68,10 +82,15 @@ Custom templates are built from a Dockerfile. The Dockerfile defines the complet
       -H "Content-Type: application/json" \
       -d '{
         "name": "my-ml",
-        "dockerfile_content": "FROM ubuntu:22.04\nRUN apt-get update && apt-get install -y python3 python3-pip\nRUN pip3 install numpy pandas scikit-learn\n",
+        "dockerfile": "FROM ubuntu:22.04\nRUN apt-get update && apt-get install -y python3 python3-pip\nRUN pip3 install numpy pandas scikit-learn\n",
         "description": "Machine learning template",
         "env": {
           "PYTHONUNBUFFERED": "1"
+        },
+        "egress": {
+          "mode": "deny_all",
+          "allow_cidrs": ["0.0.0.0/0"],
+          "deny_cidrs": ["10.0.0.0/8"]
         }
       }'
     ```
@@ -103,9 +122,12 @@ The template build pipeline converts a Dockerfile into a Firecracker-bootable ex
 1. **Docker build** — Standard `docker build` using the provided Dockerfile
 2. **Container export** — Export the built image as a tar archive
 3. **ext4 creation** — Create an ext4 filesystem and extract the tar contents into it
-4. **Init injection** — Inject init scripts for VM boot (networking, overlayfs setup, SSH)
-5. **Agent skeleton** — Copy `/home/agent` to `/etc/skel/agent-skel/` for user provisioning
-6. **Cache** — Store the result with a content-addressed cache key
+4. **Init injection** — Inject init scripts for VM boot (networking, overlayfs setup)
+5. **Daemon injection** — Install `zwrm-sandboxd`, the in-VM agent daemon that the host communicates with for command execution and file operations
+6. **Agent skeleton** — Copy `/home/agent` to `/etc/skel/agent-skel/` for user provisioning
+7. **Cache** — Store the result with a content-addressed cache key
+
+After a template image is built, the control plane creates a **golden snapshot** in the background: a pre-taken Firecracker memory+state snapshot for each VM size. When a warm-pool slot isn't available, cold-starting from a golden snapshot is faster than a full kernel boot.
 
 <Info>
 Build caching is content-addressed. The cache key includes the repository URL and commit hash. Rebuilding with no upstream changes is a no-op.
@@ -128,7 +150,7 @@ When you update a template's Dockerfile, rebuild it to create a new version:
   </Tab>
 </Tabs>
 
-Rebuilding increments the template version and triggers a new build. Existing sandboxes continue using their current image — only new sandboxes use the updated template.
+Rebuilding increments the template version, invalidates any existing golden snapshots, and triggers a new build. Existing sandboxes continue using their current image — only new sandboxes use the updated template.
 
 ## Deleting custom templates
 

--- a/sandboxes/templates.mdx
+++ b/sandboxes/templates.mdx
@@ -74,7 +74,7 @@ Custom templates are built from a Dockerfile. The Dockerfile defines the complet
     - `--egress-mode` — `allow_all` or `deny_all` default for sandboxes from this template
     - `--egress-allow-cidr CIDR` — Default allowed outbound CIDR (repeatable; implies `deny_all`)
     - `--egress-deny-cidr CIDR` — Default denied outbound CIDR (repeatable)
-    - `--egress-allow-port PORT` — Default TCP port restriction for `allow_cidrs` (repeatable)
+    - `--egress-allow-port PORT` — Default TCP port restriction for `--egress-allow-cidr` (repeatable)
   </Tab>
   <Tab title="API">
     ```bash


### PR DESCRIPTION
## Documentation update for v0.7.7

Auto-generated documentation updates based on code changes in this release.

**Review carefully before merging** — these changes were generated by
Claude Code analyzing the release diff.

### Review checklist
- [ ] API/CLI documentation is accurate
- [ ] New pages are properly linked in navigation
- [ ] Code examples are correct
- [ ] No unintended changes to existing pages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Sandboxes docs for v0.7.7: adds egress controls and updates API/CLI examples. Replaces SSH-based execution references with the in-VM agent, notes template API changes, and fixes egress docs inconsistencies.

- New Features
  - Added “Egress controls” page with per-sandbox and template-level policies; linked in nav.
  - `POST /v1/sandboxes` accepts `egress` with `mode`, `allow_cidrs`, `deny_cidrs`, `allow_ports`; `400` on invalid policy.
  - New CLI flags for egress in `sandbox create/run` and `templates create`; template defaults can be overridden at sandbox create.

- Refactors & Fixes
  - Replaced SSH references with the in-VM agent across pages; removed `503` SSH error; updated quickstart and ephemeral examples.
  - Template API now uses `dockerfile` (was `dockerfile_content`); build pipeline docs add `zwrm-sandboxd` and golden snapshot details; rebuilds invalidate snapshots.
  - Egress docs: corrected a contradictory example, aligned example response payload, and unified CLI/API terminology.

<sup>Written for commit 02e38cf4fc26c1cf22a56f4207d7895807d6a671. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

