### PR TITLE
Add self-hosting documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -93,6 +93,48 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Self-Hosting",
+        "groups": [
+          {
+            "group": "Getting Started",
+            "pages": [
+              "self-hosting/overview",
+              "self-hosting/installation",
+              "self-hosting/quickstart"
+            ]
+          },
+          {
+            "group": "Control Plane",
+            "pages": [
+              "self-hosting/control-plane",
+              "self-hosting/networking",
+              "self-hosting/proxy-and-tls"
+            ]
+          },
+          {
+            "group": "Host Agents",
+            "pages": [
+              "self-hosting/host-agent"
+            ]
+          },
+          {
+            "group": "Operations",
+            "pages": [
+              "self-hosting/multi-host",
+              "self-hosting/upgrading",
+              "self-hosting/monitoring"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "self-hosting/api-reference",
+              "self-hosting/environment-variables"
+            ]
+          }
+        ]
       }
     ],
     "global": {

--- a/index.mdx
+++ b/index.mdx
@@ -15,6 +15,9 @@ Agents have full access to the ZWRM platform: they can build, deploy, scale, and
   <Card title="Apps" icon="cloud-arrow-up" href="/apps/deploy">
     Build, deploy, and manage your applications.
   </Card>
+  <Card title="Sandboxes" icon="box" href="/sandbox">
+    Isolated microVM environments for code execution and AI agents.
+  </Card>
   <Card title="Agents" icon="robot" href="/agents/overview">
     Run coding agents with full platform access.
   </Card>
@@ -23,5 +26,8 @@ Agents have full access to the ZWRM platform: they can build, deploy, scale, and
   </Card>
   <Card title="Global Secrets" icon="vault" href="/secrets">
     Organization-wide secrets shared across all apps.
+  </Card>
+  <Card title="Self-Hosting" icon="server" href="/self-hosting/overview">
+    Run the ZWRM platform on your own infrastructure.
   </Card>
 </CardGroup>

--- a/self-hosting/api-reference.mdx
+++ b/self-hosting/api-reference.mdx
@@ -1,0 +1,70 @@
+---
+title: "API Reference"
+description: "Internal and administrative API endpoints for the control plane."
+icon: "code"
+---
+
+The control plane exposes a REST API on the configured port (default `8080`). User-facing endpoints for apps, machines, deployments, volumes, secrets, and databases are documented alongside their CLI commands in the [Guides](/quickstart) and [CLI Reference](/cli-reference).
+
+This page covers the internal and administrative endpoints used by host agents and operators.
+
+## Public (no auth)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/` | Service info (`{"service":"zwrmd","version":"..."}`) |
+| `GET` | `/metrics` | Prometheus metrics |
+| `GET` | `/v1/health` | Health check (`{"status":"healthy"}`) |
+
+## Internal (host agent auth)
+
+These endpoints are used by `zwrm-agent` for registration and image distribution. Authenticated via SHA-256 hash of the license key.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1/internal/hosts/register` | Register a host agent |
+| `POST` | `/v1/internal/hosts/{host_id}/heartbeat` | Host heartbeat |
+| `POST` | `/v1/internal/hosts/{host_id}/deregister` | Deregister a host agent |
+| `GET` | `/v1/internal/images/{digest}` | Download image by content-addressed digest |
+| `HEAD` | `/v1/internal/images/{digest}` | Check image existence |
+| `GET` | `/v1/internal/images` | List images (optional `?app_id=`) |
+
+## Host management
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/hosts` | List all hosts |
+| `GET` | `/v1/hosts/{host_id}` | Get host with capacity |
+| `POST` | `/v1/hosts/{host_id}/drain` | Initiate host drain |
+| `GET` | `/v1/hosts/{host_id}/drain-status` | Get drain progress |
+| `POST` | `/v1/hosts/{host_id}/undrain` | Cancel drain |
+| `POST` | `/v1/hosts/{host_id}/activate` | Return host from maintenance |
+
+## System
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/v1/auth/whoami` | Current user info |
+| `GET` | `/v1/status` | System status (scoped to user's org) |
+
+## Authentication
+
+Protected endpoints require one of:
+
+- **Session token**: `Authorization: Bearer <session_token>`
+- **API key**: `Authorization: Bearer <api_key>`
+- **Localhost bypass**: Requests from `127.0.0.1` or `::1` bypass auth with `host-admin` access
+
+Internal endpoints (under `/v1/internal/`) use the license key hash for authentication instead of session tokens.
+
+## Middleware
+
+All requests pass through the middleware stack in order:
+
+| Middleware | Description |
+|------------|-------------|
+| Logger | Logs `METHOD PATH STATUS DURATION BYTES` |
+| Recovery | Catches panics, returns 500 JSON |
+| CORS | Validates Origin against `cors.allowed_origins` |
+| Metrics | Records Prometheus metrics |
+| Auth | Validates Bearer token (protected routes only) |

--- a/self-hosting/control-plane.mdx
+++ b/self-hosting/control-plane.mdx
@@ -1,0 +1,165 @@
+---
+title: "Control Plane"
+description: "Configure and run the zwrmd control plane server."
+icon: "tower-control"
+---
+
+The control plane (`zwrmd`) is the central server that manages apps, deployments, VMs, volumes, secrets, databases, and sandboxes. It runs a REST API, background workers for image building and deployment, and optionally a reverse proxy, SSH proxy, and PostgreSQL proxy.
+
+## CLI flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--config` | `/etc/zwrm/config.toml` | Path to config file |
+| `--generate-config` | `false` | Generate default config and exit |
+
+## Systemd service
+
+Create `/etc/systemd/system/zwrmd.service`:
+
+```ini
+[Unit]
+Description=ZWRM Control Plane
+After=network.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/zwrmd --config /etc/zwrm/config.toml
+Restart=on-failure
+RestartSec=5
+User=root
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=zwrmd
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now zwrmd
+sudo journalctl -u zwrmd -f
+```
+
+## Configuration
+
+The control plane reads `/etc/zwrm/config.toml`. Generate a default config with `zwrmd --generate-config`.
+
+### Server
+
+```toml
+[server]
+  port = 8080
+  read_timeout = "15s"
+  write_timeout = "15s"
+  idle_timeout = "60s"
+```
+
+### Database
+
+```toml
+[database]
+  driver = "postgres"           # "sqlite" or "postgres"
+  path = "/var/lib/zwrm/state.db"  # SQLite path (single-host only)
+  url = ""                      # PostgreSQL connection string
+```
+
+<Tip>
+Use PostgreSQL for production and multi-host setups. SQLite is fine for local development.
+</Tip>
+
+### Workers
+
+```toml
+[workers]
+  pool_size = 4                 # Concurrent deployment workers
+  cleanup_interval = "30s"      # VM orphan check interval
+
+  [workers.restart]
+    enabled = true
+    default_policy = "on-failure"   # "always", "on-failure", "never"
+    max_restarts = 5
+    initial_delay = "5s"
+    max_delay = "5m"
+    healthy_reset_period = "10m"
+```
+
+### Scheduler
+
+```toml
+[scheduler]
+  strategy = "spread"           # "spread" or "pack"
+```
+
+### Build
+
+```toml
+[build]
+  images_dir = "/var/lib/zwrm/images"
+  cache_dir = "/var/lib/zwrm/cache"
+```
+
+### Secrets
+
+```toml
+[secrets]
+  master_key_path = "/var/lib/zwrm/secrets/master.key"
+  metadata_service_enabled = true
+  metadata_service_address = "169.254.169.254:1338"
+```
+
+### Volumes
+
+```toml
+[volumes]
+  max_size_mb = 51200           # 50 GB max per volume
+  max_per_app = 1
+  min_free_disk_mb = 10240      # 10 GB minimum free disk
+  storage_dir = "/var/lib/zwrm/volumes"
+```
+
+### CORS
+
+```toml
+[cors]
+  allowed_origins = ["https://*.example.com"]
+```
+
+Supports exact origins (`https://app.example.com`) and wildcard patterns (`https://*.example.com`).
+
+## Startup sequence
+
+1. Load configuration and apply environment variable overrides
+2. Initialize database (SQLite or PostgreSQL)
+3. Clean up stale Firecracker processes and reconcile machine state
+4. Set up VM networking (IPAM, NAT, iptables rules)
+5. Start background services (workers, restart manager, cache cleanup)
+6. Initialize reverse proxy, SSH proxy, and metadata server (if configured)
+7. Start HTTP server
+8. Wait for `SIGINT` or `SIGTERM`
+
+## Graceful shutdown
+
+Shutdown timeout is 30 seconds. Components stop in order: metadata server, SSH proxy, reverse proxy, API server (drains workers), HTTP server (drains connections), private networking cleanup, database close.
+
+## Authentication model
+
+- **Localhost bypass**: Requests from `127.0.0.1` or `::1` get automatic `host-admin` access
+- **Session tokens**: `Authorization: Bearer <token>` validated against the auth database
+- **API keys**: SHA-256 hashed, validated against the `apikey` table
+- **Org scoping**: All resources are scoped to the user's active organization
+
+<CardGroup cols={2}>
+  <Card title="Networking" icon="network-wired" href="/self-hosting/networking">
+    VM networking, IP forwarding, and private networking.
+  </Card>
+  <Card title="Proxy & TLS" icon="lock" href="/self-hosting/proxy-and-tls">
+    Reverse proxy, TLS, SSH proxy, and PostgreSQL proxy.
+  </Card>
+  <Card title="Environment Variables" icon="list" href="/self-hosting/environment-variables">
+    Override any config value via environment variables.
+  </Card>
+</CardGroup>

--- a/self-hosting/environment-variables.mdx
+++ b/self-hosting/environment-variables.mdx
@@ -1,0 +1,58 @@
+---
+title: "Environment Variables"
+description: "Override control plane and agent configuration via environment variables."
+icon: "list"
+---
+
+Environment variables override their corresponding config file values. For the control plane, CLI flags are not supported beyond `--config` and `--generate-config` — use environment variables or the config file instead.
+
+## Control plane
+
+| Variable | Config field | Notes |
+|----------|-------------|-------|
+| `PORT` | `server.port` | |
+| `DATABASE_DRIVER` | `database.driver` | `"sqlite"` or `"postgres"` |
+| `DATABASE_URL` | `database.url` | Also sets driver to `"postgres"` |
+| `DB_PATH` | `database.path` | SQLite file path |
+| `SUBNET` | `network.subnet` | |
+| `EXTERNAL_INTERFACE` | `network.external_interface` | |
+| `ENABLE_BRIDGE` | `network.bridge.enabled` | `"true"` to enable |
+| `BRIDGE_SUBNET` | `network.bridge.subnet` | |
+| `ENABLE_PROXY` | `proxy.enabled` | `"true"` to enable |
+| `PROXY_DOMAIN` | `proxy.domain` | |
+| `PROXY_HTTP_PORT` | `proxy.http_port` | |
+| `PROXY_HTTPS_PORT` | `proxy.https_port` | |
+| `PROXY_TLS_EMAIL` | `proxy.tls.email` | Also enables TLS |
+| `PROXY_TLS_CACHE_DIR` | `proxy.tls.cache_dir` | |
+| `HEALTH_CHECK_INTERVAL` | `proxy.health.interval` | |
+| `WORKER_POOL_SIZE` | `workers.pool_size` | |
+| `SCHEDULER_STRATEGY` | `scheduler.strategy` | `"spread"` or `"pack"` |
+| `AUTH_DATABASE_URL` | `auth.database_url` | |
+| `SECRETS_MASTER_KEY_PATH` | `secrets.master_key_path` | |
+| `SECRETS_METADATA_SERVICE_ENABLED` | `secrets.metadata_service_enabled` | `"false"` to disable |
+| `SECRETS_METADATA_SERVICE_ADDRESS` | `secrets.metadata_service_address` | |
+| `CORS_ALLOWED_ORIGINS` | `cors.allowed_origins` | Comma-separated, supports wildcards |
+| `SKIP_STARTUP_CLEANUP` | *(direct)* | Set to `"1"` to skip stale process cleanup |
+| `SOCKET_DIR` | *(direct)* | Firecracker socket directory (default: `/tmp`) |
+
+## Host agent
+
+| Variable | Config field | Notes |
+|----------|-------------|-------|
+| `AGENT_HOST_ID` | `host_id` | |
+| `AGENT_GRPC_PORT` | `grpc_port` | |
+| `AGENT_CONTROL_PLANE_URL` | `control_plane_url` | |
+| `AGENT_LICENSE_KEY` | `license_key` | |
+| `AGENT_REGION` | `region` | |
+| `AGENT_DATACENTER` | `datacenter` | |
+| `AGENT_CAPACITY_CPUS` | `capacity_cpus` | |
+| `AGENT_CAPACITY_MEMORY_MB` | `capacity_memory_mb` | |
+| `AGENT_IMAGE_CACHE_DIR` | `image_cache_dir` | |
+| `AGENT_IMAGE_CACHE_MAX_GB` | `image_cache_max_gb` | |
+| `SOCKET_DIR` | *(direct)* | Socket directory for cleanup (default: `/tmp`) |
+
+## Override precedence
+
+For the **control plane**: config file < environment variables. CLI flags (`--config`, `--generate-config`) control which config file is loaded but don't override individual values.
+
+For the **host agent**: config file < environment variables < CLI flags. CLI flags take highest precedence when provided.

--- a/self-hosting/host-agent.mdx
+++ b/self-hosting/host-agent.mdx
@@ -1,0 +1,145 @@
+---
+title: "Host Agent"
+description: "Configure and run zwrm-agent on worker hosts."
+icon: "satellite-dish"
+---
+
+The host agent (`zwrm-agent`) runs on each worker host in a multi-host cluster. It receives gRPC commands from the control plane to start, stop, and destroy VMs, pulls images from the control plane's registry, and reports resource usage via heartbeats.
+
+## CLI flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-config` | `/etc/zwrm/agent.toml` | Path to agent config file |
+| `-host-id` | from config | Override host ID |
+| `-grpc-port` | from config | Override gRPC listen port |
+| `-control-plane-url` | from config | Override control plane URL |
+
+CLI flags override config file values when provided.
+
+## Configuration
+
+```toml
+host_id = ""                              # Auto-generated UUID if empty
+grpc_port = 9090
+control_plane_url = "http://127.0.0.1:8080"
+license_key = ""
+region = ""                               # Defaults to "default" on control plane
+datacenter = ""                           # Defaults to "default" on control plane
+capacity_cpus = 4                         # Advertised CPU capacity
+capacity_memory_mb = 8192                 # Advertised memory (MB)
+image_cache_dir = "/var/lib/zwrm/image-cache"
+image_cache_max_gb = 20                   # Max cache size before LRU eviction
+```
+
+If `host_id` is empty, a UUID is auto-generated and persisted back to the config file.
+
+<Tip>
+The install script auto-detects CPU count and memory from the system and writes them to `agent.toml`.
+</Tip>
+
+## Systemd service
+
+Create `/etc/systemd/system/zwrm-agent.service`:
+
+```ini
+[Unit]
+Description=ZWRM Agent
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/zwrm-agent -config /etc/zwrm/agent.toml
+Restart=on-failure
+RestartSec=5
+User=root
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=zwrm-agent
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now zwrm-agent
+sudo journalctl -u zwrm-agent -f
+```
+
+## Registration and heartbeat
+
+### Registration
+
+On startup, the agent registers with the control plane via HTTP:
+
+```
+POST {control_plane_url}/v1/internal/hosts/register
+```
+
+The payload includes host ID, hostname, region, datacenter, IP address, gRPC port, and capacity. The agent's outbound IP is auto-detected. Registration retries with exponential backoff (1s initial, 30s max) until success.
+
+### Heartbeat
+
+Every 10 seconds, the agent sends a heartbeat:
+
+```
+POST {control_plane_url}/v1/internal/hosts/{host_id}/heartbeat
+```
+
+The heartbeat includes machine count (from `/proc/*/cmdline`), allocated memory (from `/proc/meminfo`), and allocated CPUs.
+
+If the control plane doesn't receive a heartbeat for 30 seconds, it marks the host `offline` and fails all its running machines.
+
+After 3 consecutive heartbeat failures, the agent logs a warning. When it recovers, it re-registers in the background.
+
+## gRPC service
+
+The agent exposes a gRPC service (`agent.HostAgent`) that the control plane calls to manage VMs:
+
+| RPC | Description |
+|-----|-------------|
+| `StartVM` | Start a Firecracker VM. Pulls image from registry if `image_ref` is provided. |
+| `StopVM` | Stop a running VM by killing its Firecracker process. |
+| `DestroyVM` | Destroy a VM and clean up resources (TAP, socket). |
+| `GetVMStatus` | Check if a VM process is alive. |
+| `Heartbeat` | gRPC liveness probe. |
+
+## Image cache
+
+When the control plane schedules a VM on a remote host, the agent pulls the image from the control plane's built-in registry:
+
+1. Check local cache (`{image_cache_dir}/sha256-{hex}.ext4`)
+2. If cached, touch mtime for LRU freshness and return
+3. If not cached, download from `GET {control_plane_url}/v1/internal/images/{ref}`
+4. Verify SHA256 hash matches the image ref
+5. Atomic rename to final cache path
+6. Trigger LRU eviction if cache exceeds `image_cache_max_gb`
+
+Concurrent pulls of the same image are deduplicated.
+
+## Authentication
+
+When `license_key` is configured, all communication is authenticated:
+
+- **gRPC**: SHA-256 hash of the license key sent as `Bearer <hash>` in metadata
+- **HTTP image pull**: Same hash sent as `Bearer <hash>` in Authorization header
+- **Registration**: Raw license key sent in the register request for license validation
+
+The raw key is never sent over gRPC.
+
+## Socket cleanup
+
+- **On startup**: Removes stale `firecracker-*.socket` files older than 60 seconds
+- **Every 30 seconds**: Same cleanup runs periodically
+
+The agent does not kill Firecracker processes or delete TAP devices — those are managed by the control plane.
+
+## Shutdown
+
+Triggered by `SIGINT` or `SIGTERM`:
+
+1. Cancel background tasks (heartbeat, cleanup)
+2. Deregister from control plane (5-second timeout)
+3. Graceful gRPC stop (30-second timeout for in-flight RPCs)

--- a/self-hosting/installation.mdx
+++ b/self-hosting/installation.mdx
@@ -1,0 +1,113 @@
+---
+title: "Installation"
+description: "Install the control plane, host agent, or CLI from the install script."
+icon: "download"
+---
+
+The install script supports three modes: control plane, agent, and CLI. It handles binary downloads, Firecracker setup, systemd service creation, and configuration generation.
+
+## Quick install
+
+```bash
+# Control plane (default)
+curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | sudo bash
+
+# Agent on a worker host
+curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | sudo bash -s -- \
+    --agent --control-plane-url=https://cp.example.com:8080
+
+# CLI only (no root needed)
+curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | bash -s -- --cli
+```
+
+## Modes
+
+| Mode | Flag | Description | Root |
+|------|------|-------------|------|
+| Control plane | *(default)* | Full control plane with networking, Firecracker, and systemd service | Yes |
+| Agent | `--agent` | Worker host agent with gRPC, Firecracker, and systemd service | Yes |
+| CLI | `--cli` | CLI binary only | No |
+
+## Flags
+
+| Flag | Description | Applies to | Default |
+|------|-------------|------------|---------|
+| `--agent` | Install agent mode | -- | Control plane mode |
+| `--cli` | Install CLI mode | -- | Control plane mode |
+| `--version=VERSION` | Pin to a specific version | All | Latest |
+| `--base-url=URL` | Override release download base URL | All | `https://releases.zwrm.eu/zwrmd` |
+| `--control-plane-url=URL` | Control plane URL (required for agent) | Agent | -- |
+| `--region=REGION` | Region label | Agent | -- |
+| `--datacenter=DC` | Datacenter label | Agent | -- |
+| `--license-key=KEY` | License key injected into config | Control plane, Agent | -- |
+| `--yes`, `-y` | Non-interactive, auto-confirm prompts | All | `false` |
+| `--uninstall` | Remove installation | All | `false` |
+| `--dry-run` | Show what would be done | All | `false` |
+| `--no-start` | Install but don't start the service | Control plane, Agent | `false` |
+
+## What gets installed
+
+### Control plane
+
+| Step | Description |
+|------|-------------|
+| 1 | Download `zwrmd` binary to `/usr/local/bin/zwrmd` (checksum verified) |
+| 2 | Create directories: `/etc/zwrm`, `/var/lib/zwrm/images`, `/var/lib/zwrm/cache`, `/var/lib/zwrm/certs`, `/var/lib/zwrm/secrets` |
+| 3 | Download dropbear SSH server to `/usr/local/share/zwrmd/dropbear` |
+| 4 | Generate `/etc/zwrm/config.toml` via `zwrmd --generate-config` |
+| 5 | Enable IP forwarding and install `iptables-persistent` |
+| 6 | Download Firecracker and kernel (if not present) |
+| 7 | Install `zwrmd.service` systemd unit |
+| 8 | Enable and start the service |
+
+### Agent
+
+| Step | Description |
+|------|-------------|
+| 1 | Download `zwrm-agent` binary to `/usr/local/bin/zwrm-agent` (checksum verified) |
+| 2 | Create directories: `/etc/zwrm`, `/var/lib/zwrm/image-cache` |
+| 3 | Generate `/etc/zwrm/agent.toml` with auto-detected CPU and memory capacity |
+| 4 | Enable IP forwarding |
+| 5 | Download Firecracker and kernel (if not present) |
+| 6 | Install `zwrm-agent.service` systemd unit |
+| 7 | Enable and start the service |
+
+### CLI
+
+Downloads the `zwrm` binary to `/usr/local/bin/zwrm` (as root) or `~/.local/bin/zwrm` (non-root).
+
+## Firecracker and kernel
+
+During control plane and agent installation, the script checks for Firecracker and the kernel image. If either is missing, it prompts to download them (auto-confirmed with `--yes` or piped stdin).
+
+| Component | Path | Version |
+|-----------|------|---------|
+| Firecracker | `/usr/local/bin/firecracker` | v1.10.1 |
+| Kernel | `/opt/firecracker/vmlinux-5.10.bin` | 5.10.230 |
+
+## Release channels
+
+| Channel | URL | Use case |
+|---------|-----|----------|
+| Stable | `https://releases.zwrm.eu/zwrmd` | Production |
+| Canary | `https://releases.zwrm.eu/zwrmd/canary` | Testing new builds before promotion |
+
+Install from canary:
+
+```bash
+curl -fsSL https://releases.zwrm.eu/zwrmd/canary/install.sh | sudo bash -s -- \
+    --base-url=https://releases.zwrm.eu/zwrmd/canary --version=v<git_sha> --yes --no-start
+```
+
+## Dry run
+
+Preview what the installer would do without making changes:
+
+```bash
+bash install.sh --dry-run
+bash install.sh --dry-run --agent --control-plane-url=https://cp.example.com:8080
+```
+
+<Tip>
+See [Upgrading](/self-hosting/upgrading) for upgrade and uninstall procedures.
+</Tip>

--- a/self-hosting/monitoring.mdx
+++ b/self-hosting/monitoring.mdx
@@ -1,0 +1,97 @@
+---
+title: "Monitoring"
+description: "Prometheus metrics, health checks, and log viewing."
+icon: "chart-line"
+---
+
+## Health check
+
+```bash
+curl http://localhost:8080/v1/health
+```
+
+Returns `{"status": "healthy"}` when the control plane is running.
+
+## System status
+
+```bash
+curl -H "Authorization: Bearer <token>" http://localhost:8080/v1/status
+```
+
+Returns system-wide statistics scoped to the user's organization: app count, machine count, database count, and host status.
+
+## Prometheus metrics
+
+The control plane exposes a Prometheus-compatible metrics endpoint:
+
+```bash
+curl http://localhost:8080/metrics
+```
+
+Metrics include HTTP request duration and count (by method, path, status), VM count, and host resource usage.
+
+### Scrape config
+
+```yaml
+scrape_configs:
+  - job_name: "zwrmd"
+    static_configs:
+      - targets: ["localhost:8080"]
+    metrics_path: "/metrics"
+```
+
+## Host status
+
+Monitor host health across the cluster:
+
+```bash
+zwrm host list
+```
+
+| Status | Meaning |
+|--------|---------|
+| `online` | Healthy, receiving heartbeats |
+| `offline` | No heartbeat for 30+ seconds, machines marked failed |
+| `draining` | Migrating VMs off the host |
+| `maintenance` | Drain complete, host deactivated |
+
+## Background services
+
+These services run inside `zwrmd` and are monitored via logs:
+
+| Service | Interval | Description |
+|---------|----------|-------------|
+| Local host heartbeat | 10s | Updates `last_heartbeat` in database |
+| Host health monitor | 15s | Marks hosts offline after 30s, fails their machines |
+| VM cleanup | 30s | Detects orphaned Firecracker processes, schedules restarts |
+| Restart manager | on demand | Processes restart queue with exponential backoff |
+| Cache cleanup | periodic | Evicts stale build cache entries |
+| Proxy health checker | 10s | Checks backend health, rotates unhealthy VMs out |
+
+## Logs
+
+### Control plane
+
+```bash
+sudo journalctl -u zwrmd -f
+sudo journalctl -u zwrmd --since "1 hour ago"
+```
+
+The control plane logs every request as `METHOD PATH STATUS DURATION BYTES`.
+
+### Host agent
+
+```bash
+sudo journalctl -u zwrm-agent -f
+```
+
+### VM console logs
+
+```bash
+# Via CLI
+zwrm logs --app <name>
+
+# Via API
+curl -H "Authorization: Bearer <token>" \
+  "http://localhost:8080/v1/machines/{id}/logs?lines=100"
+```

--- a/self-hosting/multi-host.mdx
+++ b/self-hosting/multi-host.mdx
@@ -1,0 +1,105 @@
+---
+title: "Multi-Host"
+description: "Distribute VMs across multiple hosts with scheduling and drain."
+icon: "diagram-project"
+---
+
+Add worker hosts running `zwrm-agent` to distribute VMs beyond a single server. The control plane schedules workloads across all healthy hosts.
+
+## Adding a host
+
+Install the agent on each worker host:
+
+```bash
+curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | sudo bash -s -- \
+    --agent \
+    --control-plane-url=https://cp.example.com:8080 \
+    --region=eu-central \
+    --datacenter=dc1
+```
+
+The agent registers automatically and begins sending heartbeats. Verify with:
+
+```bash
+zwrm host list
+```
+
+## Scheduling
+
+The control plane uses a placement scheduler to decide where new VMs run. Two strategies are available:
+
+```toml
+[scheduler]
+  strategy = "spread"    # distribute evenly across hosts
+  # strategy = "pack"    # fill hosts before using new ones
+```
+
+| Strategy | Behavior |
+|----------|----------|
+| **spread** | Distributes VMs evenly across all healthy hosts. Maximizes fault tolerance. |
+| **pack** | Fills hosts to capacity before using the next one. Minimizes host count. |
+
+Both strategies respect region and datacenter constraints when specified in the deployment.
+
+<Info>
+Apps with local volumes are pinned to the host where the volume was created, regardless of scheduler strategy. See [Volumes](/apps/volumes) for details.
+</Info>
+
+## Host health monitoring
+
+The control plane monitors host health:
+
+- **Check interval**: Every 15 seconds
+- **Offline threshold**: 30 seconds without a heartbeat
+- **On offline**: Host is marked `offline`, its executor is deregistered, and all running machines are marked `failed`
+
+When the agent reconnects and resumes heartbeats, the host is automatically re-registered.
+
+## Host management
+
+```bash
+# List all hosts with status and capacity
+zwrm host list
+
+# Get detailed info for a host
+zwrm host status <host-id>
+```
+
+## Host drain
+
+Drain a host to gracefully migrate its workloads before maintenance:
+
+```bash
+# Start draining a host
+zwrm host drain <host-id>
+
+# Check drain progress
+zwrm host drain-status <host-id>
+
+# Cancel a drain
+zwrm host undrain <host-id>
+
+# Return a host from maintenance
+zwrm host activate <host-id>
+```
+
+### Drain process
+
+1. Mark the host as draining (no new VMs scheduled)
+2. For each VM on the host:
+   - Select a target host (excluding the draining host)
+   - If the VM has volumes, transfer the ext4 image to the target via gRPC streaming
+   - Destroy the original VM
+   - Start a replacement VM on the target host
+   - Wait for health check to pass
+3. If any migration fails, rollback: destroy the replacement, restore original volume mounts
+
+<Warning>
+Volume transfers are one-time copies, not replication. After drain, the volume lives on the new host and subsequent deploys pin to that host.
+</Warning>
+
+## Image distribution
+
+When the scheduler places a VM on a remote agent host, the agent pulls the app image from the control plane's built-in image registry. Images are content-addressed (SHA256) and cached locally on each agent with LRU eviction.
+
+See [Host Agent](/self-hosting/host-agent) for cache configuration.

--- a/self-hosting/networking.mdx
+++ b/self-hosting/networking.mdx
@@ -1,0 +1,72 @@
+---
+title: "Networking"
+description: "VM networking, IP allocation, and private networking."
+icon: "network-wired"
+---
+
+ZWRM allocates a /30 subnet per VM with a TAP device for host-to-guest networking. NAT and iptables rules handle outbound connectivity.
+
+## Network configuration
+
+```toml
+[network]
+  subnet = "172.16.0.0/16"         # VM network subnet
+  external_interface = "eth0"      # Host interface for NAT
+```
+
+The default `/16` subnet provides ~16,000 VMs (each VM uses a /30 block of 4 IPs).
+
+## IP forwarding
+
+IP forwarding must be enabled for VMs to reach the internet. The install script handles this automatically:
+
+```bash
+sudo sysctl -w net.ipv4.ip_forward=1
+echo "net.ipv4.ip_forward=1" | sudo tee /etc/sysctl.d/99-zwrmd.conf
+```
+
+## IPAM
+
+Each VM is allocated a /30 subnet from the configured range:
+
+- `.1` — TAP gateway (host side)
+- `.2` — Guest IP (VM side)
+
+VMs receive their IP via kernel boot parameters (static configuration, no DHCP). IP allocations are tracked in the database and released when VMs are destroyed.
+
+## NAT rules
+
+ZWRM creates iptables NAT masquerade and FORWARD rules at startup so VMs can reach external networks. Without `iptables-persistent`, these rules are lost on host reboot but recreated when `zwrmd` starts.
+
+To persist rules across reboots:
+
+```bash
+sudo apt-get install -y iptables-persistent
+sudo systemctl enable netfilter-persistent
+```
+
+## Private networking
+
+Enable firewall-based private networking so VMs within the same app can communicate:
+
+```toml
+[network.bridge]
+  enabled = true
+  name = "zwrmd0"
+  subnet = "10.0.0.0/16"
+```
+
+When enabled, ZWRM creates a dedicated iptables chain with a default DROP rule. Same-app VMs get ACCEPT rules inserted before the DROP, allowing inter-VM communication while isolating apps from each other.
+
+<Warning>
+Private networking uses iptables rules, not a Linux bridge for inter-VM traffic. Bridge attachment is intentionally avoided because it breaks host-to-VM L3 routing.
+</Warning>
+
+## Firewall chain
+
+The ZWRM iptables chain is managed automatically:
+
+- **On startup**: Creates the chain and inserts default DROP
+- **On deploy/scale**: Adds ACCEPT rules for same-app VM pairs
+- **On destroy**: Removes rules for destroyed VMs
+- **On shutdown**: Cleans up NAT rules and the firewall chain

--- a/self-hosting/overview.mdx
+++ b/self-hosting/overview.mdx
@@ -1,0 +1,82 @@
+---
+title: "Self-Hosting"
+description: "Run the ZWRM platform on your own infrastructure."
+icon: "server"
+---
+
+ZWRM can be self-hosted on any Linux server with KVM support. You run the control plane and optionally add host agents to scale across multiple machines.
+
+## Components
+
+| Component | Binary | Role |
+|-----------|--------|------|
+| **Control plane** | `zwrmd` | Central server that manages apps, deployments, VMs, databases, sandboxes, secrets, and the reverse proxy. Runs Firecracker VMs on the local host. |
+| **Host agent** | `zwrm-agent` | Runs on additional worker hosts. Receives gRPC commands from the control plane to start/stop VMs, pulls images, and reports resource usage via heartbeats. |
+| **CLI** | `zwrm` | Client tool for developers. Talks to the control plane REST API. |
+
+## Architecture
+
+### Single-host
+
+The simplest setup: one server runs `zwrmd`, which handles everything — API, reverse proxy, TLS, image builds, and Firecracker VMs.
+
+```
+Developer (zwrm CLI)
+    │
+    ▼
+┌──────────────────────────┐
+│  zwrmd (control plane)   │
+│  ├── REST API            │
+│  ├── Reverse proxy + TLS │
+│  ├── Build pipeline      │
+│  ├── VM manager          │
+│  └── PostgreSQL state DB │
+└──────────────────────────┘
+    │
+    ▼
+  Firecracker VMs
+```
+
+### Multi-host
+
+Add `zwrm-agent` on worker hosts to distribute VMs across machines. The control plane schedules workloads using spread or pack strategies.
+
+```
+Developer (zwrm CLI)
+    │
+    ▼
+┌──────────────────────────┐
+│  zwrmd (control plane)   │
+│  ├── REST API            │
+│  ├── Reverse proxy + TLS │
+│  ├── gRPC server         │
+│  ├── Scheduler           │
+│  └── Image registry      │
+└──────────┬───────────────┘
+           │ gRPC
+     ┌─────┴─────┐
+     ▼           ▼
+┌──────────┐ ┌──────────┐
+│ zwrm-agent│ │ zwrm-agent│
+│ (host 1) │ │ (host 2) │
+└──────────┘ └──────────┘
+     │           │
+     ▼           ▼
+   VMs         VMs
+```
+
+## Prerequisites
+
+- **Linux** (amd64 or arm64) with **KVM** support (`/dev/kvm`)
+- **Docker** daemon (for building app images)
+- **PostgreSQL** database (for control plane state)
+- **Root access** (required for TAP devices, Firecracker, iptables)
+
+<CardGroup cols={2}>
+  <Card title="Installation" icon="download" href="/self-hosting/installation">
+    Install the control plane, agent, or CLI.
+  </Card>
+  <Card title="Quickstart" icon="rocket" href="/self-hosting/quickstart">
+    Go from bare server to running apps in minutes.
+  </Card>
+</CardGroup>

--- a/self-hosting/proxy-and-tls.mdx
+++ b/self-hosting/proxy-and-tls.mdx
@@ -1,0 +1,124 @@
+---
+title: "Proxy & TLS"
+description: "Reverse proxy, TLS termination, SSH proxy, PostgreSQL proxy, and authentication service."
+icon: "lock"
+---
+
+The control plane includes several optional proxy and service components that can be enabled in `config.toml`.
+
+## Reverse proxy
+
+Routes HTTP traffic to apps by hostname. Each app gets `<app-name>.<domain>`.
+
+```toml
+[proxy]
+  enabled = true
+  domain = "example.com"
+  http_port = 80
+  https_port = 443
+  request_timeout = "30s"
+  api_forward = "127.0.0.1:8080"   # Forward root domain to API (optional)
+```
+
+### TLS with Let's Encrypt
+
+```toml
+[proxy.tls]
+  enabled = true
+  email = "admin@example.com"
+  cache_dir = "/var/lib/zwrm/certs"
+  allowed_hosts = []               # Additional TLS hostnames
+```
+
+Certificates are automatically obtained and renewed via Let's Encrypt. The cache directory stores certificates on disk.
+
+### Health checks
+
+The proxy monitors backend health and removes unhealthy VMs from the rotation:
+
+```toml
+[proxy.health]
+  interval = "10s"
+  timeout = "2s"
+  failure_threshold = 3            # Failures before marking unhealthy
+  recovery_threshold = 2           # Successes before marking healthy
+  startup_grace_period = "30s"     # Grace period before checks start
+```
+
+## SSH proxy
+
+Enables `zwrm ssh` access through NAT to VMs that don't have public IPs. Uses certificate-based authentication.
+
+```toml
+[ssh_proxy]
+  enabled = true
+  port = 2222
+  host_key_path = "/var/lib/zwrm/ssh_proxy_host_key"
+  idle_timeout = "10m"
+
+  [ssh_proxy.ca]
+    ca_path = "/var/lib/zwrm/ssh_ca"
+    certificate_ttl = "24h"
+```
+
+The SSH CA keypair is generated automatically on first start if it doesn't exist.
+
+## PostgreSQL proxy
+
+External PostgreSQL access via HAProxy with TLS. Allows developers to connect to managed databases from outside the cluster.
+
+```toml
+[postgres_proxy]
+  enabled = true
+  domain = "pg.example.com"
+  port = 5432
+  haproxy_config_path = "/etc/haproxy/haproxy.cfg"
+  haproxy_map_path = "/etc/haproxy/postgres.map"
+  haproxy_reload_command = "systemctl reload haproxy"
+  connection_timeout = "10s"
+  client_timeout = "1h"
+  server_timeout = "1h"
+
+  [postgres_proxy.tls]
+    certbot_enabled = true
+    certbot_email = "admin@example.com"
+    certbot_dns_plugin = "route53"
+    certbot_credentials_path = "/etc/certbot/credentials"
+```
+
+<Info>
+The PostgreSQL proxy requires HAProxy to be installed separately. ZWRM generates the HAProxy config and reloads it when databases are created or destroyed.
+</Info>
+
+## Authentication service
+
+ZWRM can run a Better Auth-based authentication service as a subprocess for multi-user setups.
+
+```toml
+[auth]
+  database_url = "postgres://user:pass@localhost:5432/zwrm_auth"
+  max_orgs_per_user = 5
+
+  [auth.service]
+    enabled = true
+    internal_port = 3000
+    auth_dir = "/usr/local/share/zwrmd/auth"
+    routes = ["auth.example.com"]
+
+    [auth.service.env]
+      BETTER_AUTH_SECRET = ""       # JWT signing secret (openssl rand -base64 32)
+      BETTER_AUTH_URL = "https://auth.example.com"
+      RESEND_API_KEY = ""           # For transactional emails
+      TRUSTED_ORIGINS = "https://dashboard.example.com"
+      # Optional OAuth providers:
+      # GITHUB_CLIENT_ID = ""
+      # GITHUB_CLIENT_SECRET = ""
+      # GOOGLE_CLIENT_ID = ""
+      # GOOGLE_CLIENT_SECRET = ""
+```
+
+The auth service requires a separate PostgreSQL database and a Node.js runtime.
+
+<Tip>
+For single-user setups with localhost access only, you don't need the auth service — localhost requests bypass authentication automatically.
+</Tip>

--- a/self-hosting/quickstart.mdx
+++ b/self-hosting/quickstart.mdx
@@ -1,0 +1,100 @@
+---
+title: "Quickstart"
+description: "Go from a bare Linux server to running apps in minutes."
+icon: "rocket"
+---
+
+This guide walks through a single-host setup. You'll install the control plane, configure it, and deploy your first app.
+
+## Prerequisites
+
+- A Linux server (amd64 or arm64) with KVM support
+- Docker installed and running
+- A PostgreSQL database (local or remote)
+- A domain pointing to your server (for TLS)
+
+<Steps>
+  <Step title="Install the control plane">
+    ```bash
+    curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | sudo bash
+    ```
+
+    This installs `zwrmd`, Firecracker, generates a default config, and starts the systemd service.
+  </Step>
+
+  <Step title="Configure the control plane">
+    Edit `/etc/zwrm/config.toml`:
+
+    ```toml
+    [database]
+      url = "postgres://user:pass@localhost:5432/zwrmd?sslmode=disable"
+
+    [proxy]
+      enabled = true
+      domain = "example.com"
+
+      [proxy.tls]
+        enabled = true
+        email = "admin@example.com"
+    ```
+
+    Restart to apply:
+
+    ```bash
+    sudo systemctl restart zwrmd
+    ```
+  </Step>
+
+  <Step title="Verify the control plane is running">
+    ```bash
+    curl http://localhost:8080/v1/health
+    ```
+
+    You should see:
+
+    ```json
+    {"status": "healthy"}
+    ```
+  </Step>
+
+  <Step title="Install and configure the CLI">
+    On your dev machine:
+
+    ```bash
+    curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | bash -s -- --cli
+    ```
+
+    Point it at your control plane:
+
+    ```bash
+    zwrm auth login --api-url https://example.com:8080
+    ```
+  </Step>
+
+  <Step title="Deploy your first app">
+    ```bash
+    mkdir my-app && cd my-app
+    zwrm init
+    zwrm deploy
+    ```
+
+    Your app is now running on a Firecracker microVM behind TLS.
+  </Step>
+</Steps>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Configuration" icon="gear" href="/self-hosting/control-plane">
+    Full config.toml reference for the control plane.
+  </Card>
+  <Card title="Multi-Host" icon="diagram-project" href="/self-hosting/multi-host">
+    Add worker hosts to distribute VMs across machines.
+  </Card>
+  <Card title="Proxy & TLS" icon="lock" href="/self-hosting/proxy-and-tls">
+    Configure the reverse proxy, SSH proxy, and PostgreSQL proxy.
+  </Card>
+  <Card title="Monitoring" icon="chart-line" href="/self-hosting/monitoring">
+    Prometheus metrics, health checks, and log viewing.
+  </Card>
+</CardGroup>

--- a/self-hosting/upgrading.mdx
+++ b/self-hosting/upgrading.mdx
@@ -1,0 +1,80 @@
+---
+title: "Upgrading"
+description: "Upgrade, version pin, and uninstall ZWRM components."
+icon: "arrow-up-right-dots"
+---
+
+## Upgrade
+
+Re-run the install command to upgrade. The binary is replaced atomically (downloaded to temp, then moved). Existing configuration is preserved — the config generation step is skipped when the config file already exists.
+
+```bash
+# Upgrade control plane to latest
+curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | sudo bash
+
+# Upgrade agent to latest
+curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | sudo bash -s -- \
+    --agent --control-plane-url=https://cp.example.com:8080
+
+# Upgrade CLI to latest
+curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | bash -s -- --cli
+
+# Pin to a specific version
+curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | sudo bash -s -- --version=v1.2.0
+```
+
+## Canary testing
+
+Test a new build before promoting to stable:
+
+```bash
+# Install canary control plane (without starting)
+curl -fsSL https://releases.zwrm.eu/zwrmd/canary/install.sh | sudo bash -s -- \
+    --base-url=https://releases.zwrm.eu/zwrmd/canary \
+    --version=v<git_sha> --yes --no-start
+
+# Verify the binary
+/usr/local/bin/zwrmd --version
+
+# Start when ready
+sudo systemctl start zwrmd
+```
+
+## Self-hosted mirrors
+
+Override the release URL for self-hosted or mirrored distributions:
+
+```bash
+curl -fsSL https://releases.zwrm.eu/zwrmd/install.sh | sudo bash -s -- \
+    --base-url=https://mirror.internal/zwrmd
+```
+
+Binaries are downloaded from `{base_url}/{version}/{binary}-{os}-{arch}`. Checksums are fetched from `{base_url}/{version}/checksums.txt` and verified with `sha256sum`.
+
+## Uninstall
+
+```bash
+# Uninstall control plane
+sudo bash install.sh --uninstall
+
+# Uninstall agent
+sudo bash install.sh --uninstall --agent
+
+# Uninstall CLI
+bash install.sh --uninstall --cli
+```
+
+### What gets removed
+
+| Mode | Removed | Preserved |
+|------|---------|-----------|
+| Control plane | Binary, systemd service, `/usr/local/share/zwrmd/`, sysctl config, iptables rules | `/etc/zwrm/` (config), `/var/lib/zwrm/` (data), Firecracker, kernel |
+| Agent | Binary, systemd service, sysctl config | `/etc/zwrm/` (config), `/var/lib/zwrm/` (data) |
+| CLI | Binary | -- |
+
+To fully remove config and data:
+
+```bash
+sudo rm -rf /etc/zwrm
+sudo rm -rf /var/lib/zwrm
+```


### PR DESCRIPTION
## Summary

- Add a new **Self-Hosting** tab with 12 pages covering the server-side components (`zwrmd` control plane and `zwrm-agent` host agent)
- Content adapted from the internal docs in `cloud/docs/` (control-plane.md, agent.md, install.md) into Mintlify MDX format
- Add **Sandboxes** and **Self-Hosting** cards to the homepage

### New pages

| Group | Pages |
|-------|-------|
| Getting Started | Overview, Installation, Quickstart |
| Control Plane | Configuration, Networking, Proxy & TLS |
| Host Agents | Host Agent (config, gRPC, registration, image cache) |
| Operations | Multi-Host, Upgrading, Monitoring |
| Reference | API Reference (internal/admin endpoints), Environment Variables |

## Test plan

- [ ] Run `mintlify dev` and verify all 12 new pages render correctly
- [ ] Verify Self-Hosting tab appears in navigation with all 5 groups
- [ ] Check homepage shows Sandboxes and Self-Hosting cards
- [ ] Verify cross-reference links between self-hosting and guide pages work
- [ ] Spot-check config.toml snippets against actual defaults in cloud repo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Self-Hosting docs section that explains how to install and run the `zwrmd` control plane and `zwrm-agent`, plus networking, proxy/TLS, monitoring, and upgrades. Also adds Sandboxes and Self-Hosting cards to the docs homepage.

- **New Features**
  - New "Self-Hosting" tab with 12 MDX pages: Overview, Installation, Quickstart; Control Plane config, Networking, Proxy & TLS; Host Agent; Multi-Host, Upgrading, Monitoring; API Reference, Environment Variables.
  - Updated `docs.json` to add the new tab and groups, with cross-links between guides.
  - Homepage now shows "Sandboxes" and "Self-Hosting" cards.

<sup>Written for commit 84e0f152897b477634d8fe9f66b12aaae8838b0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

