### PR TITLE
docs: update for v0.7.9

### DIFF
--- a/apps/deploy.mdx
+++ b/apps/deploy.mdx
@@ -59,6 +59,12 @@ zwrm deploy --app my-other-app --context ./other-app
 
 ZWRM uses content-addressed caching based on your Dockerfile, build context, and build args. If nothing has changed, the build is skipped entirely. Use `--force-build` to bypass the cache when needed.
 
+## Concurrent deploy protection
+
+Only one deployment can be in progress per app at a time. If you trigger a new deploy while one is already running, the API returns `409 Conflict` with the message `A deployment is already in progress for this app`. Wait for the current deployment to finish (or fail) before starting another.
+
+If any critical setup step fails — deploying secrets, creating volumes, applying firewall rules, or registering with the proxy — the deployment is marked failed immediately with a descriptive error. Check `zwrm status` for the error message.
+
 ## Health checks
 
 After deploying, ZWRM automatically health-checks your app's public URL:

--- a/postgres/backups.mdx
+++ b/postgres/backups.mdx
@@ -104,3 +104,11 @@ zwrm postgres restore status <restore-id>
 ```
 
 Shows the restore type, status, target database ID, and any error details.
+
+## In-place restore safety
+
+When restoring over an existing database (in-place restore), ZWRM applies several safety measures to prevent data loss:
+
+- **Old volume retention** — the original data volume is kept for 24 hours after the swap completes. A background reaper deletes it once the retention window expires. If the restored database turns out to be unhealthy during that window, contact your administrator to recover from the retained volume.
+- **Post-swap health check** — after swapping the database record to point at the restored VM and volume, ZWRM polls the database for up to 30 seconds. If the restored database does not become healthy, the restore is marked failed and the old volume is retained for recovery.
+- **Deferred S3 backup deletion** — old pre-restore backups are only deleted after a new base backup of the restored database succeeds. If the new base backup fails, the old backups are kept so you retain some restore coverage.


### PR DESCRIPTION
## Documentation update for v0.7.9

Auto-generated documentation updates based on code changes in this release.

**Review carefully before merging** — these changes were generated by
Claude Code analyzing the release diff.

### Review checklist
- [ ] API/CLI documentation is accurate
- [ ] New pages are properly linked in navigation
- [ ] Code examples are correct
- [ ] No unintended changes to existing pages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs update for v0.7.9: adds “Concurrent deploy protection” to app deploys and “In-place restore safety” for Postgres restores. Covers 409 Conflict behavior, immediate fail on critical setup errors with `zwrm status` guidance, 24-hour old volume retention, post-swap health checks, and deferred deletion of old backups.

<sup>Written for commit 11199b7803b94b74ecdcfef5ab77552445d19e5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

